### PR TITLE
Implement realtime game state updates

### DIFF
--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -1,0 +1,99 @@
+# Realtime Functionality
+
+This document explains the realtime functionality implemented for the poker game to automatically update game state when the database changes.
+
+## Overview
+
+The realtime system uses Supabase's real-time capabilities to listen for PostgreSQL changes and automatically update the UI without requiring manual refreshes or polling.
+
+## Components
+
+### Core Hooks
+
+1. **`usePokerRealtime`** - Main hook that listens to all poker-related table changes
+   - Listens to: `poker_games`, `poker_players`, `poker_actions`, `poker_cards`
+   - Automatically invalidates tRPC queries when changes occur
+   - Includes debouncing to batch rapid changes
+   - Provides connection status and error tracking
+
+2. **`useGameRealtime`** - Specific hook for games table changes only
+3. **`usePlayerRealtime`** - Specific hook for player-related changes
+
+### Components
+
+1. **`RealtimeStatus`** - Visual indicator showing connection status
+   - Shows connection state, errors, and last update time
+   - Only visible when there are issues (by default)
+
+## Implementation Details
+
+### Database Tables Monitored
+
+- **poker_games**: Game state, status, current round, pot, etc.
+- **poker_players**: Player positions, stacks, bets, folded status
+- **poker_actions**: Player actions (bet, check, fold, etc.)
+- **poker_cards**: Dealt cards and community cards
+
+### Query Invalidation Strategy
+
+When realtime changes are detected:
+1. Changes are debounced (100ms) to batch rapid updates
+2. Relevant tRPC queries are invalidated:
+   - `player.getAllGames`
+   - `game.getAll`
+3. React Query automatically refetches the data
+4. UI updates reflect the new state
+
+### Integration Points
+
+The realtime hooks are integrated into:
+- `ClientGameInterface` - Main game interface
+- `PublicGamesComponent` - Games list
+- Individual game components receive updates automatically
+
+## Usage
+
+### Basic Integration
+
+```tsx
+import { usePokerRealtime } from "~/app/_components/Realtime";
+
+function MyGameComponent() {
+  // This will automatically handle realtime updates
+  const status = usePokerRealtime();
+  
+  // Your existing tRPC queries will be automatically invalidated
+  const [games] = api.player.getAllGames.useSuspenseQuery();
+  
+  return <div>Games update automatically!</div>;
+}
+```
+
+### With Status Indicator
+
+```tsx
+import { RealtimeStatus } from "~/app/_components/Realtime";
+
+function MyComponent() {
+  return (
+    <div>
+      <RealtimeStatus showDetails={true} />
+      {/* Your game content */}
+    </div>
+  );
+}
+```
+
+## Benefits
+
+1. **Automatic Updates**: Game state updates across all connected clients immediately
+2. **Reduced Server Load**: No need for polling or frequent manual refreshes
+3. **Better UX**: Players see changes from other players in real-time
+4. **Consistency**: All clients stay synchronized with the database state
+
+## Technical Notes
+
+- Uses Supabase Realtime with PostgreSQL replication
+- Implements debouncing to prevent excessive updates
+- Maintains both immediate manual invalidation (for user actions) and realtime updates (for consistency)
+- Includes error handling and connection status monitoring

--- a/src/app/_components/PublicGames/PublicGames.tsx
+++ b/src/app/_components/PublicGames/PublicGames.tsx
@@ -11,12 +11,16 @@ import {
 	TableRow,
 } from "@mui/material";
 import { api } from "~/trpc/react";
+import { usePokerRealtime } from "../Realtime/usePokerRealtime";
 import { useGameMutations } from "./useGameMutations";
 
 export function PublicGamesComponent() {
 	const [games] = api.player.getAllGames.useSuspenseQuery();
 	const { handleJoinGame, handleLeaveGame, isGameBeingModified, createGame, deleteGame } =
 		useGameMutations();
+
+	// Enable realtime updates for games list
+	const realtimeStatus = usePokerRealtime();
 
 	return (
 		<Stack spacing={2}>

--- a/src/app/_components/Realtime/RealtimeStatus.tsx
+++ b/src/app/_components/Realtime/RealtimeStatus.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Chip, Tooltip } from "@mui/material";
+import { usePokerRealtime } from "./usePokerRealtime";
+
+interface RealtimeStatusProps {
+  showDetails?: boolean;
+}
+
+export function RealtimeStatus({ showDetails = false }: RealtimeStatusProps) {
+  const status = usePokerRealtime();
+
+  const getStatusColor = () => {
+    if (!status.isConnected) return "error";
+    if (status.connectionErrors > 0) return "warning";
+    return "success";
+  };
+
+  const getStatusText = () => {
+    if (!status.isConnected) return "Disconnected";
+    if (status.connectionErrors > 0) return "Issues";
+    return "Connected";
+  };
+
+  const getTooltipText = () => {
+    const parts = [
+      `Status: ${status.isConnected ? "Connected" : "Disconnected"}`,
+      `Errors: ${status.connectionErrors}`,
+    ];
+    
+    if (status.lastUpdate) {
+      parts.push(`Last update: ${status.lastUpdate.toLocaleTimeString()}`);
+    }
+    
+    return parts.join("\n");
+  };
+
+  if (!showDetails && status.isConnected && status.connectionErrors === 0) {
+    // Don't show anything when everything is working normally and details aren't requested
+    return null;
+  }
+
+  return (
+    <Tooltip title={getTooltipText()} arrow>
+      <Chip
+        label={`Realtime: ${getStatusText()}`}
+        color={getStatusColor()}
+        size="small"
+        variant={status.isConnected ? "filled" : "outlined"}
+      />
+    </Tooltip>
+  );
+}

--- a/src/app/_components/Realtime/index.tsx
+++ b/src/app/_components/Realtime/index.tsx
@@ -8,3 +8,10 @@ export default function Realtime() {
 		</Suspense>
 	);
 }
+
+export { RealtimeTest } from "./realtime";
+export { useGameRealtime } from "./useGameRealtime";
+export { usePlayerRealtime } from "./usePlayerRealtime";
+export { usePokerRealtime } from "./usePokerRealtime";
+export { RealtimeStatus } from "./RealtimeStatus";
+export { RealtimeTest as RealtimeTestNew } from "./test-realtime";

--- a/src/app/_components/Realtime/useGameRealtime.ts
+++ b/src/app/_components/Realtime/useGameRealtime.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { type RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+import { useEffect, useRef } from "react";
+import { api } from "~/trpc/react";
+import { createClient } from "~/supabase/client";
+
+const supabase = createClient();
+
+type GameRealtimePayload = RealtimePostgresChangesPayload<{
+  id: string;
+  status: string;
+  current_round: string;
+  current_highest_bet: number;
+  current_player_turn: string;
+  pot: number;
+  updated_at: string;
+  [key: string]: any;
+}>;
+
+export function useGameRealtime() {
+  const utils = api.useUtils();
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+
+  useEffect(() => {
+    // Create a channel for listening to games table changes
+    const channel = supabase
+      .channel("games-realtime")
+      .on(
+        "postgres_changes",
+        {
+          event: "*", // Listen to all events (INSERT, UPDATE, DELETE)
+          schema: "public",
+          table: "poker_games", // Specifically listen to the games table
+        },
+        async (payload: GameRealtimePayload) => {
+          console.log("Game state changed:", payload);
+          
+          // Invalidate relevant tRPC queries to trigger refetch
+          try {
+            await Promise.all([
+              utils.player.getAllGames.invalidate(),
+              utils.game.getAll.invalidate(),
+            ]);
+          } catch (error) {
+            console.error("Error invalidating queries after realtime update:", error);
+          }
+        }
+      )
+      .subscribe((status) => {
+        console.log("Games realtime subscription status:", status);
+      });
+
+    channelRef.current = channel;
+
+    // Cleanup function
+    return () => {
+      if (channelRef.current) {
+        void channelRef.current.unsubscribe();
+        channelRef.current = null;
+      }
+    };
+  }, [utils.player.getAllGames, utils.game.getAll]);
+
+  return {
+    // Return any useful status if needed
+    isConnected: channelRef.current?.state === "joined",
+  };
+}

--- a/src/app/_components/Realtime/usePlayerRealtime.ts
+++ b/src/app/_components/Realtime/usePlayerRealtime.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { type RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+import { useEffect, useRef } from "react";
+import { api } from "~/trpc/react";
+import { createClient } from "~/supabase/client";
+
+const supabase = createClient();
+
+type PlayerRealtimePayload = RealtimePostgresChangesPayload<{
+  id: string;
+  game_id: string;
+  user_id: string;
+  stack: number;
+  current_bet: number;
+  has_folded: boolean;
+  seat: number;
+  [key: string]: any;
+}>;
+
+export function usePlayerRealtime() {
+  const utils = api.useUtils();
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+
+  useEffect(() => {
+    // Create a channel for listening to player and action changes
+    const channel = supabase
+      .channel("players-realtime")
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public", 
+          table: "poker_players", // Listen to players table changes
+        },
+        async (payload: PlayerRealtimePayload) => {
+          console.log("Player state changed:", payload);
+          
+          // Invalidate game queries when player state changes
+          try {
+            await utils.player.getAllGames.invalidate();
+          } catch (error) {
+            console.error("Error invalidating queries after player realtime update:", error);
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "poker_actions", // Listen to actions table changes
+        },
+        async (payload) => {
+          console.log("Action recorded:", payload);
+          
+          // Invalidate game queries when new actions are recorded
+          try {
+            await utils.player.getAllGames.invalidate();
+          } catch (error) {
+            console.error("Error invalidating queries after action realtime update:", error);
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "poker_cards", // Listen to cards table changes
+        },
+        async (payload) => {
+          console.log("Cards changed:", payload);
+          
+          // Invalidate game queries when cards are dealt/changed
+          try {
+            await utils.player.getAllGames.invalidate();
+          } catch (error) {
+            console.error("Error invalidating queries after cards realtime update:", error);
+          }
+        }
+      )
+      .subscribe((status) => {
+        console.log("Players realtime subscription status:", status);
+      });
+
+    channelRef.current = channel;
+
+    return () => {
+      if (channelRef.current) {
+        void channelRef.current.unsubscribe();
+        channelRef.current = null;
+      }
+    };
+  }, [utils.player.getAllGames]);
+
+  return {
+    isConnected: channelRef.current?.state === "joined",
+  };
+}

--- a/src/app/_components/Realtime/usePokerRealtime.ts
+++ b/src/app/_components/Realtime/usePokerRealtime.ts
@@ -1,0 +1,164 @@
+"use client";
+
+import { type RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "~/trpc/react";
+import { createClient } from "~/supabase/client";
+
+const supabase = createClient();
+
+type RealtimePayload = RealtimePostgresChangesPayload<Record<string, any>>;
+
+interface PokerRealtimeStatus {
+  isConnected: boolean;
+  lastUpdate: Date | null;
+  connectionErrors: number;
+}
+
+export function usePokerRealtime() {
+  const utils = api.useUtils();
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+  const [status, setStatus] = useState<PokerRealtimeStatus>({
+    isConnected: false,
+    lastUpdate: null,
+    connectionErrors: 0,
+  });
+
+  // Debounce invalidation to prevent too many simultaneous requests
+  const invalidationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const pendingInvalidationsRef = useRef<Set<string>>(new Set());
+
+  const performInvalidation = useCallback(async () => {
+    const invalidations = Array.from(pendingInvalidationsRef.current);
+    pendingInvalidationsRef.current.clear();
+
+    try {
+      console.log("Performing realtime invalidations for:", invalidations);
+      
+      // Always invalidate the main game queries
+      await Promise.all([
+        utils.player.getAllGames.invalidate(),
+        utils.game.getAll.invalidate(),
+      ]);
+
+      setStatus(prev => ({ 
+        ...prev, 
+        lastUpdate: new Date(),
+        connectionErrors: 0 
+      }));
+    } catch (error) {
+      console.error("Error invalidating queries after realtime update:", error);
+      setStatus(prev => ({ 
+        ...prev, 
+        connectionErrors: prev.connectionErrors + 1 
+      }));
+    }
+  }, [utils.player.getAllGames, utils.game.getAll]);
+
+  const scheduleInvalidation = useCallback((source: string) => {
+    pendingInvalidationsRef.current.add(source);
+    
+    if (invalidationTimeoutRef.current) {
+      clearTimeout(invalidationTimeoutRef.current);
+    }
+
+    // Debounce by 100ms to batch multiple rapid changes
+    invalidationTimeoutRef.current = setTimeout(() => {
+      void performInvalidation();
+    }, 100);
+  }, [performInvalidation]);
+
+  useEffect(() => {
+    console.log("Setting up poker realtime subscriptions...");
+
+    const channel = supabase
+      .channel("poker-realtime")
+      // Games table changes
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "poker_games",
+        },
+        (payload: RealtimePayload) => {
+          const gameId = payload.new && 'id' in payload.new ? String(payload.new.id) : 'unknown';
+          console.log("Game state changed:", payload.eventType, gameId);
+          scheduleInvalidation(`games:${gameId}`);
+        }
+      )
+      // Players table changes  
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "poker_players",
+        },
+        (payload: RealtimePayload) => {
+          const gameId = payload.new && 'game_id' in payload.new ? String(payload.new.game_id) : 'unknown';
+          console.log("Player state changed:", payload.eventType, gameId);
+          scheduleInvalidation(`players:${gameId}`);
+        }
+      )
+      // Actions table changes
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public", 
+          table: "poker_actions",
+        },
+        (payload: RealtimePayload) => {
+          const gameId = payload.new && 'game_id' in payload.new ? String(payload.new.game_id) : 'unknown';
+          console.log("Action recorded:", payload.eventType, gameId);
+          scheduleInvalidation(`actions:${gameId}`);
+        }
+      )
+      // Cards table changes
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "poker_cards",
+        },
+        (payload: RealtimePayload) => {
+          const gameId = payload.new && 'game_id' in payload.new ? String(payload.new.game_id) : 'unknown';
+          console.log("Cards changed:", payload.eventType, gameId);
+          scheduleInvalidation(`cards:${gameId}`);
+        }
+      )
+      .subscribe((subscriptionStatus) => {
+        console.log("Poker realtime subscription status:", subscriptionStatus);
+        setStatus(prev => ({
+          ...prev,
+          isConnected: subscriptionStatus === "SUBSCRIBED",
+        }));
+      });
+
+    channelRef.current = channel;
+
+    return () => {
+      console.log("Cleaning up poker realtime subscriptions...");
+      
+      if (invalidationTimeoutRef.current) {
+        clearTimeout(invalidationTimeoutRef.current);
+        invalidationTimeoutRef.current = null;
+      }
+
+      if (channelRef.current) {
+        void channelRef.current.unsubscribe();
+        channelRef.current = null;
+      }
+
+      setStatus({
+        isConnected: false,
+        lastUpdate: null,
+        connectionErrors: 0,
+      });
+    };
+  }, [scheduleInvalidation]);
+
+  return status;
+}

--- a/src/app/_components/TableInterface/ClientGameInterface.tsx
+++ b/src/app/_components/TableInterface/ClientGameInterface.tsx
@@ -3,6 +3,7 @@
 import { Box, Paper, Tab, Tabs } from "@mui/material";
 import { useState } from "react";
 import { api } from "~/trpc/react";
+import { usePokerRealtime, RealtimeStatus } from "../Realtime";
 import Game from "./Game";
 
 interface TabPanelProps {
@@ -39,6 +40,9 @@ function TabPanel(props: TabPanelProps) {
 export function ClientGameInterface() {
 	const [currentGame, setCurrentGame] = useState(0);
 	const [games] = api.player.getAllGames.useSuspenseQuery({ joinedOnly: true });
+	
+	// Enable realtime updates for game state
+	const realtimeStatus = usePokerRealtime();
 
 	const handleGameChange = (event: React.SyntheticEvent, newValue: number) => {
 		setCurrentGame(newValue);
@@ -46,7 +50,7 @@ export function ClientGameInterface() {
 
 	return (
 		<Box className="flex grow flex-col">
-			<Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+			<Box sx={{ borderBottom: 1, borderColor: "divider" }} className="flex items-center justify-between px-2">
 				<Tabs
 					value={currentGame}
 					onChange={handleGameChange}
@@ -63,6 +67,7 @@ export function ClientGameInterface() {
 						/>
 					))}
 				</Tabs>
+				<RealtimeStatus />
 			</Box>
 
 			{games.map((game, index) => (

--- a/src/app/_components/TableInterface/Game.tsx
+++ b/src/app/_components/TableInterface/Game.tsx
@@ -343,6 +343,7 @@ export default function Game({ game }: GameProps) {
 
 /**
  * TODO:
- * - Integrate realtime updates to update the game state without making extra requests
  * - Create a better UI to display the game state
+ * - Add visual indicators for realtime connection status
+ * - Optimize performance for large numbers of concurrent games
  */


### PR DESCRIPTION
Realtime game state updates were implemented to synchronize the UI with database changes. A new `usePokerRealtime` hook was introduced, listening to `poker_games`, `poker_players`, `poker_actions`, and `poker_cards` tables via Supabase Realtime.

Upon detecting changes, the hook automatically invalidates relevant tRPC queries, specifically `player.getAllGames` and `game.getAll`, triggering UI refetches. Updates are debounced by 100ms to batch rapid changes and optimize performance.

A `RealtimeStatus` component was created to provide visual feedback on the connection health, displaying status, errors, and last update time, appearing only when issues arise. For development, a `RealtimeTest` component was added to verify functionality.

The `usePokerRealtime` hook was integrated into `ClientGameInterface` and `PublicGamesComponent`, ensuring instant updates for game lists and active game states. This provides a smoother user experience by eliminating the need for manual refreshes and reducing server load. Comprehensive documentation was added to `docs/realtime.md`.