### PR TITLE
Implement delayed serverless bot moves with waitUntil

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@trpc/client": "^11.4.4",
     "@trpc/server": "^11.4.4",
     "@trpc/tanstack-react-query": "^11.4.4",
+    "@vercel/functions": "^2.2.13",
     "class-variance-authority": "^0.7.1",
     "client-only": "^0.0.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@trpc/tanstack-react-query':
         specifier: ^11.4.4
         version: 11.4.4(@tanstack/react-query@5.85.3(react@19.1.0))(@trpc/client@11.4.4(@trpc/server@11.4.4(typescript@5.9.2))(typescript@5.9.2))(@trpc/server@11.4.4(typescript@5.9.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
+      '@vercel/functions':
+        specifier: ^2.2.13
+        version: 2.2.13
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1422,6 +1425,9 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@20.19.10':
     resolution: {integrity: sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==}
 
@@ -1595,6 +1601,19 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/functions@2.2.13':
+    resolution: {integrity: sha512-14ArBSIIcOBx9nrEgaJb4Bw+en1gl6eSoJWh8qjifLl5G3E4dRXCFOT8HP+w66vb9Wqyd1lAQBrmRhRwOj9X9A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@2.0.2':
+    resolution: {integrity: sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==}
+    engines: {node: '>= 18'}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -4324,6 +4343,8 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/ms@2.1.0': {}
+
   '@types/node@20.19.10':
     dependencies:
       undici-types: 6.21.0
@@ -4499,6 +4520,15 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vercel/functions@2.2.13':
+    dependencies:
+      '@vercel/oidc': 2.0.2
+
+  '@vercel/oidc@2.0.2':
+    dependencies:
+      '@types/ms': 2.1.0
+      ms: 2.1.3
 
   '@vitest/expect@3.2.4':
     dependencies:

--- a/src/app/api/internal/sim/invoke/route.ts
+++ b/src/app/api/internal/sim/invoke/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createCallerFactory } from "@/trpc/init";
+import { appRouter } from "@/trpc/routers/_app";
+import { createTRPCContext } from "@/trpc/init";
+
+const bodySchema = z.object({
+  gameId: z.string().uuid(),
+  handId: z.number().int().optional(),
+  expectedPlayerId: z.string().uuid().optional(),
+});
+
+export async function POST(req: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ ok: true, skipped: "prod" }, { status: 200 });
+  }
+
+  const secret = process.env.SIM_BOT_SECRET;
+  const header = req.headers.get("x-sim-bot-secret");
+  if (!secret || header !== secret) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid body" }, { status: 400 });
+  }
+
+  const baseCtx = await createTRPCContext();
+  const caller = createCallerFactory(appRouter)({ ...baseCtx, internalSimAuth: true });
+
+  try {
+    const result = await caller.simBot.performOneMove(parsed.data);
+    return NextResponse.json(result);
+  } catch (err: unknown) {
+    return NextResponse.json({ error: (err as Error)?.message ?? "error" }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/sim/schedule/route.ts
+++ b/src/app/api/internal/sim/schedule/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { waitUntil } from "@vercel/functions";
+import { z } from "zod";
+
+const bodySchema = z.object({
+  gameId: z.string().uuid(),
+  handId: z.number().int().optional(),
+  expectedPlayerId: z.string().uuid().optional(),
+  delayMs: z.number().int().min(0).max(10000).default(2000),
+});
+
+function getBaseUrl(): string {
+  const explicit = process.env.NEXT_PUBLIC_APP_URL;
+  if (explicit) return explicit;
+  const vercelUrl = process.env.VERCEL_URL;
+  if (vercelUrl) return `https://${vercelUrl}`;
+  return "http://localhost:3000";
+}
+
+export async function POST(req: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ ok: true, skipped: "prod" }, { status: 200 });
+  }
+
+  const secret = process.env.SIM_BOT_SECRET;
+  const header = req.headers.get("x-sim-bot-secret");
+  if (!secret || header !== secret) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid body" }, { status: 400 });
+  }
+
+  const { delayMs, ...payload } = parsed.data;
+  const baseUrl = getBaseUrl();
+
+  console.log("[sim-bot] schedule", { ...payload, delay: delayMs });
+
+  waitUntil(
+    (async () => {
+      await new Promise((res) => setTimeout(res, delayMs));
+      try {
+        await fetch(`${baseUrl}/api/internal/sim/invoke`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-sim-bot-secret": secret,
+          },
+          body: JSON.stringify(payload),
+        });
+      } catch (err) {
+        // Intentionally minimal logging
+        console.log("[sim-bot] schedule_error", { error: (err as Error)?.message });
+      }
+    })()
+  );
+
+  return NextResponse.json({ ok: true, scheduled: true });
+}

--- a/src/lib/simulator/registry.ts
+++ b/src/lib/simulator/registry.ts
@@ -1,22 +1,10 @@
-import { BotManager } from "./manager";
+// Legacy BotManager disabled in favor of serverless scheduling with waitUntil.
+// Keeping exports as no-ops to avoid breaking imports.
 
-const managers = new Map<string, BotManager>();
-
-export function getManager(tableId: string): BotManager {
-  let mgr = managers.get(tableId);
-  if (!mgr) {
-    mgr = new BotManager({ tableId });
-    managers.set(tableId, mgr);
-  }
-  return mgr;
+export function startManager(_tableId: string) {
+  // no-op
 }
 
-export function startManager(tableId: string) {
-  const mgr = getManager(tableId);
-  void mgr.start();
-}
-
-export function stopManager(tableId: string) {
-  const mgr = managers.get(tableId);
-  if (mgr) mgr.stop();
+export function stopManager(_tableId: string) {
+  // no-op
 }

--- a/src/lib/simulator/scheduler.ts
+++ b/src/lib/simulator/scheduler.ts
@@ -1,0 +1,67 @@
+import { db } from "@/db";
+import { games } from "@/db/schema/games";
+import { players } from "@/db/schema/players";
+import { and, eq } from "drizzle-orm";
+import { makeRng } from "./rng";
+import type { SimulatorConfig, StrategyConfig } from "./types";
+
+function getBaseUrl(): string {
+  const explicit = process.env.NEXT_PUBLIC_APP_URL;
+  if (explicit) return explicit;
+  const vercelUrl = process.env.VERCEL_URL;
+  if (vercelUrl) return `https://${vercelUrl}`;
+  return "http://localhost:3000";
+}
+
+export async function scheduleNextBotMoveIfNeeded(gameId: string): Promise<void> {
+  if (process.env.NODE_ENV === "production") return;
+  if (process.env.SIM_BOT_ENABLED === "false") return;
+
+  const [row] = await db.select().from(games).where(eq(games.id, gameId)).limit(1);
+  if (!row) return;
+
+  const config: SimulatorConfig = (row.simulatorConfig as unknown as SimulatorConfig) || ({ enabled: false } as SimulatorConfig);
+  if (!config.enabled || config.paused) return;
+  if (!row.currentPlayerTurn) return;
+
+  const currentPlayerId = String(row.currentPlayerTurn);
+  const [pl] = await db
+    .select()
+    .from(players)
+    .where(and(eq(players.gameId, gameId), eq(players.id, currentPlayerId)))
+    .limit(1);
+  if (!pl) return;
+
+  const strategyCfg: StrategyConfig | undefined =
+    (config.perSeatStrategy && config.perSeatStrategy[currentPlayerId]) || config.defaultStrategy;
+  if (!strategyCfg || strategyCfg.id === "human") return;
+
+  const delays = config.delays ?? { minMs: 1800, maxMs: 2600, speedMultiplier: 1 };
+  const rng = makeRng(config.seed);
+  const jitter = delays.minMs + Math.floor(rng() * Math.max(0, (delays.maxMs - delays.minMs + 1)));
+  const delayMs = Math.max(0, Math.floor(jitter / Math.max(0.1, delays.speedMultiplier ?? 1)));
+
+  const baseUrl = getBaseUrl();
+  const secret = process.env.SIM_BOT_SECRET || "";
+
+  console.log("[sim-bot] schedule_request", {
+    gameId,
+    handId: row.handId,
+    expectedPlayerId: currentPlayerId,
+    delay: delayMs,
+  });
+
+  await fetch(`${baseUrl}/api/internal/sim/schedule`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-sim-bot-secret": secret,
+    },
+    body: JSON.stringify({
+      gameId,
+      handId: row.handId,
+      expectedPlayerId: currentPlayerId,
+      delayMs,
+    }),
+  });
+}

--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -49,6 +49,8 @@ export const createTRPCContext = async () => {
   return {
     user,
     supabase,
+    // Internal simulator auth flag; only set true by internal routes
+    internalSimAuth: false as boolean,
   };
 };
 
@@ -86,6 +88,17 @@ export const nonProdProcedure = t.procedure.use(({ next }) => {
 export const devOnlyProcedure = protectedProcedure.use(({ next }) => {
   if (process.env.NODE_ENV === "production") {
     throw new Error("Operation not allowed in production");
+  }
+  return next();
+});
+
+// Internal-only procedure for simulator bot invocations (non-prod only)
+export const simInternalProcedure = t.procedure.use(({ ctx, next }) => {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("Operation not allowed in production");
+  }
+  if (!ctx.internalSimAuth) {
+    throw new Error("Unauthorized internal simulator call");
   }
   return next();
 });

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -4,12 +4,14 @@ import { authRouter } from "./auth";
 import { devRouter } from "./dev";
 import { gameRouter } from "./game";
 import { simulatorRouter } from "./simulator";
+import { simBotRouter } from "./simBot";
 
 export const appRouter = createTRPCRouter({
   auth: authRouter,
   game: gameRouter,
   dev: devRouter,
   simulator: simulatorRouter,
+  simBot: simBotRouter,
   hello: baseProcedure
     .input(
       z.object({

--- a/src/trpc/routers/simBot.ts
+++ b/src/trpc/routers/simBot.ts
@@ -1,0 +1,140 @@
+import { db } from "@/db";
+import { games } from "@/db/schema/games";
+import { players } from "@/db/schema/players";
+import { handleActionPure, dbGameToPureGame } from "@/lib/poker/engineAdapter";
+import { makeRng } from "@/lib/simulator/rng";
+import { makeStrategy } from "@/lib/simulator/strategies";
+import type { SimulatorConfig, StrategyConfig } from "@/lib/simulator/types";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { createTRPCRouter, simInternalProcedure } from "../init";
+
+function resolveBaseUrl(): string {
+  const explicit = process.env.NEXT_PUBLIC_APP_URL;
+  if (explicit) return explicit;
+  const vercelUrl = process.env.VERCEL_URL;
+  if (vercelUrl) return `https://${vercelUrl}`;
+  return "http://localhost:3000";
+}
+
+export const simBotRouter = createTRPCRouter({
+  performOneMove: simInternalProcedure
+    .input(
+      z.object({
+        gameId: z.string().uuid(),
+        handId: z.number().int().optional(),
+        expectedPlayerId: z.string().uuid().optional(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      // Global gate
+      if (process.env.SIM_BOT_ENABLED === "false") {
+        return { ok: true, skipped: "global-disabled" } as const;
+      }
+
+      // Load fresh game
+      const [gameRow] = await db
+        .select()
+        .from(games)
+        .where(eq(games.id, input.gameId))
+        .limit(1);
+      if (!gameRow) return { ok: true, skipped: "game-not-found" } as const;
+
+      // Per-game gate
+      const config: SimulatorConfig = (gameRow.simulatorConfig as unknown as SimulatorConfig) || ({ enabled: false } as SimulatorConfig);
+      if (!config.enabled) return { ok: true, skipped: "sim-disabled" } as const;
+
+      // Idempotency guards
+      if (typeof input.handId === "number" && gameRow.handId !== input.handId) {
+        return { ok: true, skipped: "hand-advanced" } as const;
+      }
+      if (!gameRow.currentPlayerTurn) {
+        return { ok: true, skipped: "no-turn" } as const;
+      }
+      if (input.expectedPlayerId && input.expectedPlayerId !== gameRow.currentPlayerTurn) {
+        return { ok: true, skipped: "turn-changed" } as const;
+      }
+
+      // Determine strategy for current player
+      const currentPlayerTurn = String(gameRow.currentPlayerTurn);
+      const [pl] = await db
+        .select()
+        .from(players)
+        .where(and(eq(players.gameId, input.gameId), eq(players.id, currentPlayerTurn)))
+        .limit(1);
+      if (!pl) return { ok: true, skipped: "player-not-found" } as const;
+
+      const strategyCfg: StrategyConfig | undefined =
+        (config.perSeatStrategy && config.perSeatStrategy[currentPlayerTurn]) || config.defaultStrategy;
+      if (!strategyCfg) return { ok: true, skipped: "no-strategy" } as const;
+      if (strategyCfg.id === "human") return { ok: true, skipped: "not-bot" } as const;
+
+      // Fresh pure state to decide
+      const pure = await dbGameToPureGame(input.gameId);
+      if (pure.handId !== gameRow.handId) return { ok: true, skipped: "hand-advanced" } as const;
+      if (pure.currentPlayerTurn !== currentPlayerTurn) return { ok: true, skipped: "turn-changed" } as const;
+
+      const strat = makeStrategy(strategyCfg);
+      const decision = strat.decide({ game: pure, playerId: currentPlayerTurn });
+      if (!decision) return { ok: true, skipped: "no-decision" } as const;
+
+      console.log("[sim-bot] action", { action: decision.action, amount: decision.amount ?? null, strategy: strat.id });
+
+      // Persist exactly one action via engine
+      await handleActionPure({
+        gameId: input.gameId,
+        playerId: currentPlayerTurn,
+        action: decision.action,
+        amount: decision.amount,
+        actorSource: "bot",
+        botStrategy: strat.id,
+      } as unknown as Parameters<typeof handleActionPure>[0]);
+
+      // Reload to decide whether to schedule next hop
+      const [afterRow] = await db
+        .select()
+        .from(games)
+        .where(eq(games.id, input.gameId))
+        .limit(1);
+      if (!afterRow || !afterRow.currentPlayerTurn) return { ok: true, done: true } as const;
+
+      const nextPlayerId = String(afterRow.currentPlayerTurn);
+      const nextStrategyCfg: StrategyConfig | undefined =
+        (config.perSeatStrategy && config.perSeatStrategy[nextPlayerId]) || config.defaultStrategy;
+
+      if (nextStrategyCfg && nextStrategyCfg.id !== "human") {
+        // Jitter based on config
+        const delays = config.delays ?? { minMs: 1500, maxMs: 2500, speedMultiplier: 1 };
+        const rng = makeRng(config.seed);
+        const jitter =
+          delays.minMs + Math.floor(rng() * Math.max(0, (delays.maxMs - delays.minMs + 1)));
+        const delayMs = Math.max(0, Math.floor(jitter / Math.max(0.1, delays.speedMultiplier ?? 1)));
+
+        console.log("[sim-bot] next-hop", {
+          gameId: input.gameId,
+          handId: afterRow.handId,
+          expectedPlayerId: nextPlayerId,
+          delay: delayMs,
+        });
+
+        const baseUrl = resolveBaseUrl();
+        const secret = process.env.SIM_BOT_SECRET || "";
+        // Fire-and-forget; outer request must trigger via scheduler route
+        await fetch(`${baseUrl}/api/internal/sim/schedule`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-sim-bot-secret": secret,
+          },
+          body: JSON.stringify({
+            gameId: input.gameId,
+            handId: afterRow.handId,
+            expectedPlayerId: nextPlayerId,
+            delayMs,
+          }),
+        });
+      }
+
+      return { ok: true, done: true } as const;
+    }),
+});

--- a/src/trpc/routers/simulator.ts
+++ b/src/trpc/routers/simulator.ts
@@ -1,7 +1,7 @@
 import { db } from "@/db";
 import { games } from "@/db/schema/games";
 import { requireDevAccess } from "@/lib/permissions";
-import { startManager } from "@/lib/simulator/registry";
+// Legacy manager disabled; replaced by serverless scheduler
 import type { SimulatorConfig } from "@/lib/simulator/types";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -29,7 +29,7 @@ export const simulatorRouter = createTRPCRouter({
         .set({ simulatorConfig: config as unknown as object })
         .where(eq(games.id, input.tableId));
 
-      startManager(input.tableId);
+      // no-op: scheduling is serverless now
       return { success: true };
     }),
 
@@ -57,7 +57,7 @@ export const simulatorRouter = createTRPCRouter({
         .update(games)
         .set({ simulatorConfig: next as unknown as object })
         .where(eq(games.id, input.tableId));
-      startManager(input.tableId);
+      // no-op: scheduling is serverless now
       return { success: true };
     }),
 
@@ -88,7 +88,7 @@ export const simulatorRouter = createTRPCRouter({
         .update(games)
         .set({ simulatorConfig: next as unknown as object })
         .where(eq(games.id, input.tableId));
-      startManager(input.tableId);
+      // no-op: scheduling is serverless now
       return { success: true };
     }),
 


### PR DESCRIPTION
Implement serverless bot turns using Vercel `waitUntil()` for delayed self-calls, replacing the legacy BotManager.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b81fc69-6c47-4d21-a63c-f7cddacee2f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b81fc69-6c47-4d21-a63c-f7cddacee2f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

