### PR TITLE
Add turn ms property to game schema

### DIFF
--- a/src/db/schema/games.ts
+++ b/src/db/schema/games.ts
@@ -31,6 +31,8 @@ export const games = pgTable("poker_games", {
   pot: integer("pot").default(0).notNull(),
   bigBlind: integer("big_blind").default(20).notNull(),
   smallBlind: integer("small_blind").default(10).notNull(),
+  // Maximum time per turn in milliseconds (client/server timers)
+  turnMs: integer("turn_ms").default(30000).notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
   lastAction: PgEnumAction("last_action").default("check"),
   lastBetAmount: integer("last_bet_amount").default(0),


### PR DESCRIPTION
Add `turnMs` column to the `poker_games` schema to make turn duration configurable from the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-51596348-0d85-4aba-b0ff-7a326e582d29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51596348-0d85-4aba-b0ff-7a326e582d29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

